### PR TITLE
Changes regarding the binaries installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
       - main
   schedule:
     - cron: "0 2 * * 0"
+  workflow_dispatch:
 
 defaults:
   run:

--- a/molecule/2.3/tests/test_default.py
+++ b/molecule/2.3/tests/test_default.py
@@ -102,7 +102,7 @@ def test_package(host, get_vars):
     """
     """
     packages = get_vars.get("loki_packages")
-    install_path = get_vars.get("loki_install_path")
+    install_path = get_vars.get("binaries_install_path")
 
     for pack in packages:
         _file = "{}/{}".format(install_path, pack)

--- a/molecule/2.4/tests/test_default.py
+++ b/molecule/2.4/tests/test_default.py
@@ -102,7 +102,7 @@ def test_package(host, get_vars):
     """
     """
     packages = get_vars.get("loki_packages")
-    install_path = get_vars.get("loki_install_path")
+    install_path = get_vars.get("binaries_install_path")
 
     for pack in packages:
         f = host.file("{}/{}".format(install_path, pack))

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -104,7 +104,7 @@ def test_package(host, get_vars):
     """
     """
     packages = get_vars.get("loki_packages")
-    install_path = get_vars.get("loki_install_path")
+    install_path = get_vars.get("binaries_install_path")
 
     for pack in packages:
         f = host.file("{}/{}".format(install_path, pack))

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,7 +12,7 @@
 
 - name: create loki configuration
   template:
-    src: "loki/{{ loki_main_version }}/loki.yml.j2"
+    src: "loki/{{ loki_minor_version }}/loki.yml.j2"
     dest: "{{ loki_config_dir }}/loki.yml"
     force: true
     owner: root

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -31,27 +31,20 @@
     - name: propagate loki binaries
       copy:
         src: "{{ loki_local_tmp_directory }}/{{ item }}-linux-amd64"
-        dest: "{{ loki_install_path }}/{{ item }}"
+        dest: "{{ binaries_install_path }}/{{ item }}"
         mode: 0755
         owner: "{{ loki_system_user }}"
         group: "{{ loki_system_group }}"
+      notify:
+        - restart loki
 
     - name: make files executable
       file:
-        path: "{{ loki_install_path }}/{{ item }}"
+        path: "{{ binaries_install_path }}/{{ item }}"
         mode: 0755
         owner: "{{ loki_system_user }}"
         group: "{{ loki_system_group }}"
   when:
     - stat_file_binary.stat.exists
-
-- name: create link to binary
-  file:
-    src: "{{ loki_install_path }}/{{ item }}"
-    dest: /usr/bin/{{ item }}
-    state: link
-    force: true
-  notify:
-    - restart loki
 
 ...

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -29,7 +29,7 @@
 
 - name: detect installed loki version
   stat:
-    path: "{{ loki_install_path }}/loki"
+    path: "{{ binaries_install_path }}/loki"
   register: stat_loki_binary
   ignore_errors: yes
 
@@ -60,23 +60,6 @@
     home: /nonexistent
   when:
     - loki_system_user != "root"
-
-- name: create install directory
-  file:
-    path: "{{ loki_install_path }}"
-    state: directory
-    owner: "{{ loki_system_user }}"
-    group: "{{ loki_system_group }}"
-    mode: 0755
-
-- name: fix directory rights for {{ loki_install_path | dirname }}
-  file:
-    path: "{{ loki_install_path | dirname }}"
-    state: directory
-    owner: "{{ loki_system_user }}"
-    group: "{{ loki_system_group }}"
-    mode: 0755
-    recurse: true
 
 - name: merge loki server configuration between defaults and custom
   set_fact:

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -31,6 +31,7 @@
   stat:
     path: "{{ loki_install_path }}/loki"
   register: stat_loki_binary
+  ignore_errors: yes
 
 - name: create local tmp directory
   become: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 
 loki_main_version: "{{ loki_version[0:3] }}"
+binaries_install_path: /usr/local/bin
 
-loki_install_path: /usr/local/bin/loki/{{ loki_version }}
 
 loki_local_tmp_directory: "{{
   lookup('env', 'CUSTOM_LOCAL_TMP_DIRECTORY') |

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 
-loki_main_version: "{{ loki_version[0:3] }}"
 binaries_install_path: /usr/local/bin
 
+loki_minor_version: "{{ loki_version.split('.', maxsplit=1) | join('.') }}"
 
 loki_local_tmp_directory: "{{
   lookup('env', 'CUSTOM_LOCAL_TMP_DIRECTORY') |


### PR DESCRIPTION
here are some commits i created regarding the handling of binaries. i'm already opening this pr b/c i don't understand the tests' failure and would be happy about advice: the failure seems to appear in the context of an aspect i didn't change (creation of a temporary folder on localhost) and i'm wondering where the expectations that `molecule converge` checks are defined.

i plan to add at least two further changes to this branch:
- detecting the currently installed version, possibly skipping a binaries' deployment
- optionally downloading binaries directly to the target host